### PR TITLE
Extra channels: change mavlink upstream head

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/PX4/GpsDrivers.git
 [submodule "libs/mavlink/include/mavlink/v2.0"]
 	path = libs/mavlink/include/mavlink/v2.0
-	url = https://github.com/mavlink/c_library_v2.git
+	url = https://github.com/SwiftEngineering/c_library_v2.git


### PR DESCRIPTION
The extra channels for Qgroundcontrol were added in mavlink messages in SwiftEngineering's fork of c_library_v2. This updates the .gitmodules and points to swift's master.